### PR TITLE
Issue/7 Add Request method (GET/POST/etc.) option param to RequestFilter data class

### DIFF
--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -1,8 +1,11 @@
 package com.appham.mockinizer
 
 import okhttp3.Request
+import okhttp3.RequestBody
+import okio.Buffer
 
 data class RequestFilter(
+    val method: Method = Method.GET,
     val path: String? = null,
     val body: String? = null
 ) {
@@ -11,8 +14,26 @@ data class RequestFilter(
 
         fun from(request: Request) =
             RequestFilter(
+                method = getMethodOrDefault(request.method),
                 path = request.url.encodedPath,
-                body = request.body?.toString()
+                body = request.body?.asString()
             )
+
+        private fun getMethodOrDefault(method:String) =
+            try {
+                Method.valueOf(method)
+            } catch (e:IllegalArgumentException) {
+                Method.GET
+            }
     }
+}
+
+enum class Method {
+    GET, POST, PUT, PATCH, DELETE;
+}
+
+fun RequestBody.asString(): String {
+    val buffer = Buffer()
+    writeTo(buffer)
+    return buffer.readUtf8()
 }

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -5,8 +5,8 @@ import okhttp3.RequestBody
 import okio.Buffer
 
 data class RequestFilter(
-    val method: Method = Method.GET,
     val path: String? = null,
+    val method: Method = Method.GET,
     val body: String? = null
 ) {
 
@@ -14,8 +14,8 @@ data class RequestFilter(
 
         fun from(request: Request) =
             RequestFilter(
-                method = getMethodOrDefault(request.method),
                 path = request.url.encodedPath,
+                method = getMethodOrDefault(request.method),
                 body = request.body?.asString()
             )
 

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -28,10 +28,10 @@ internal class MockinizerInterceptorTest {
         RequestFilter(path = "/typicode/demo/private") to MockResponse().apply {
             setResponseCode(403)
         },
-        RequestFilter(method = Method.DELETE, path = "/typicode/demo/delete") to MockResponse().apply {
+        RequestFilter(path = "/typicode/demo/delete", method = Method.DELETE ) to MockResponse().apply {
             setResponseCode(200)
         },
-        RequestFilter(method = Method.POST, path = "/typicode/demo/post", body = """{"hey":"ya"}""" ) to MockResponse().apply {
+        RequestFilter(path = "/typicode/demo/post", method = Method.POST, body = """{"hey":"ya"}""" ) to MockResponse().apply {
             setResponseCode(200)
             setBody("""{"foo":"bar"}""")
         }


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/7

### Description
Add Request method (GET/POST/etc.) option param to RequestFilter data class. 
If request method isn't defined then GET will be assumed.

### Test
Added more cases including request method params to the junit5 TestData arguments
