### PR TITLE
issue#8 add RequestFilter for Headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         mockito_kotlin_version = '2.1.0'
         junit_version = '4.12'
         junit5_version = '5.5.1'
+        assertj_version = '3.11.0'
         ext_junit_version = '1.1.0'
         testrunner_version = '1.2.0'
     }

--- a/mockinizer/build.gradle
+++ b/mockinizer/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5_version"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
+    testImplementation "org.assertj:assertj-core:$assertj_version"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -1,13 +1,22 @@
 package com.appham.mockinizer
 
+import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.RequestBody
 import okio.Buffer
 
+/**
+ * This class is to define the requests that should get filtered and served by the mock server.
+ * @param path the path part of the request url. The default is null
+ * @param method the method of the request. The default is GET
+ * @param body the request body. Cannot be used together with GET requests. The default is null
+ * @param headers the http headers to filter. The default is empty headers
+ */
 data class RequestFilter(
     val path: String? = null,
     val method: Method = Method.GET,
-    val body: String? = null
+    val body: String? = null,
+    val headers: Headers = Headers.headersOf()
 ) {
 
     companion object {
@@ -16,7 +25,8 @@ data class RequestFilter(
             RequestFilter(
                 path = request.url.encodedPath,
                 method = getMethodOrDefault(request.method),
-                body = request.body?.asString()
+                body = request.body?.asString(),
+                headers = request.headers
             )
 
         private fun getMethodOrDefault(method:String) =

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-Issue link: #
+Issue link: https://github.com/donfuxx/Mockinizer/issues/
 
 ### Description
 


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/8

### Description
Added a new constructor parameter to the `RequestFilter` class to allow filtering by okhttp `Headers`. All headers must exactly match the request headers to return a mock response.
Also added assertJ for more readable unit test results.
TODO: maybe add a 'contains' header functionality

### Test
add and run new unit tests
