### PR TITLE
Issue/16 - Allow mocking without having to specify a body

### DIFF
--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -15,7 +15,11 @@ class MockinizerInterceptor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
 
-        fun findMockResponse(request: Request) = mocks[RequestFilter.from(request)]
+        fun findMockResponse(request: Request): MockResponse? {
+            return with(RequestFilter.from(request)) {
+                mocks[this] ?: mocks[this.copy(body = null)]
+            }
+        }
 
         fun Interceptor.Chain.findServer(): HttpUrl =
             when (val mockResponse = findMockResponse(request())) {

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -34,6 +34,15 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
     },
 
     RequestFilter(
+        path = "/typicode/demo/foo",
+        method = Method.POST,
+        body = null
+    ) to MockResponse().apply {
+        setResponseCode(200)
+        setBody("""{"title":"I don't care which body you posted!"}""")
+    },
+
+    RequestFilter(
         path = "/typicode/demo/header",
         headers = Headers.headersOf("name", "value")
     ) to MockResponse().apply {

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -59,6 +59,8 @@ internal class MockinizerInterceptorTest {
     }
 
     private fun args() = mutableListOf(
+
+        // Test requests that should NOT get mocked:
         TestData(RequestFilter(), null),
         TestData(RequestFilter(path = "banana"), null),
         TestData(RequestFilter(method = Method.DELETE, body = """{"type":"apple"}"""), null),
@@ -66,6 +68,8 @@ internal class MockinizerInterceptorTest {
         TestData(RequestFilter(method = Method.PUT, path = "banana", body = """{"type":"apple"}"""), null),
         TestData(RequestFilter(method = Method.POST, path = "banana", body = """{"type":"apple"}"""), null)
     ).apply {
+
+        // All requests from mockinizer mocks map should get mocked:
         addAll(mocks.map { TestData(it.key, it.value) })
     }.stream()
 


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/16

### Description
now it will be possible to set body = null to ignore the body

### Test
added new unit tests