### PR TITLE
Issue/20 - Mockinizer not working with UI Tests using OkHttpIdlingResourceRule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven_gradle_version = '2.1'
         kotlin_version = '1.3.41'
         kotlin_coroutines_version = '1.2.2'
-        appcompat_version = '1.0.2'
+        appcompat_version = '1.1.0'
         retrofit_version = '2.5.0'
         mockserver_version = '4.0.1'
         logginginterceptor_version = '3.12.1'

--- a/mockinizer/build.gradle
+++ b/mockinizer/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     androidTestImplementation "com.squareup.okhttp3:logging-interceptor:$logginginterceptor_version"
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$mockserver_version"
 
+    androidTestImplementation 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'
     androidTestImplementation "androidx.test:runner:$testrunner_version"
     androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockWebServerTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockWebServerTest.kt
@@ -1,0 +1,96 @@
+package com.appham.mockinizer
+
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
+import com.jakewharton.espresso.OkHttp3IdlingResource
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+internal class MockWebServerTest {
+
+    private val okHttpClient: OkHttpClient by lazy {
+        okHttpClientBuilder.build()
+    }
+
+    private val okHttpClientBuilder: OkHttpClient.Builder by lazy {
+        OkHttpClient.Builder()
+    }
+
+    inner class OkHttpIdlingResourceRule : TestRule {
+
+        private val resource: IdlingResource = OkHttp3IdlingResource.create(
+            "okhttp",
+            okHttpClient
+        )
+
+        override fun apply(base: Statement, description: Description): Statement {
+            return object : Statement() {
+                override fun evaluate() {
+                    IdlingRegistry.getInstance().register(resource)
+                    base.evaluate()
+                    IdlingRegistry.getInstance().unregister(resource)
+                }
+            }
+        }
+    }
+
+    private fun createRetrofit(mockWebServer: MockWebServer = MockWebServer().configure()): Retrofit {
+        val interceptor = HttpLoggingInterceptor()
+        interceptor.level = HttpLoggingInterceptor.Level.BODY
+        val client =
+            okHttpClientBuilder.addInterceptor(interceptor).mockinize(mocks, mockWebServer).build()
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @get:Rule
+    var rule = OkHttpIdlingResourceRule()
+
+    @Test
+    fun testStartStopStaticMockServer() {
+        val mockServer = MockWebServer().configure()
+        var api = createRetrofit(mockServer).create(TestApi::class.java)
+        api.getPosts().execute()
+        assertThat(mockServer.port).isEqualTo(34567)
+
+        Mockinizer.shutDown()
+        assertThat(mockServer.port).isEqualTo(34567)
+
+        api = createRetrofit(mockServer).create(TestApi::class.java)
+        api.getPosts().execute()
+        assertThat(mockServer.port).isEqualTo(34567)
+    }
+
+    @Test
+    fun testStartStopCustomMockServer() {
+        val mockServer = MockWebServer().configure()
+        var api = createRetrofit(mockServer).create(TestApi::class.java)
+        api.getPosts().execute()
+        assertThat(mockServer.port).isEqualTo(34567)
+
+        mockServer.shutdown()
+        assertThat(mockServer.port).isEqualTo(34567)
+
+        api = createRetrofit(mockServer).create(TestApi::class.java)
+        api.getPosts().execute()
+        assertThat(mockServer.port).isEqualTo(34567)
+    }
+
+    @After
+    fun tearDown() {
+        Mockinizer.shutDown()
+    }
+}

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -1,5 +1,6 @@
 package com.appham.mockinizer
 
+import org.junit.AfterClass
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -100,6 +101,14 @@ internal class MockinizerAndroidTest {
         assertEquals(expectedBody, actualResponse.body())
         assertEquals(expectedStatusCode, actualResponse.code())
         assertEquals(expectedMethod, actualResponse.raw().request.method)
+    }
+
+    companion object {
+
+        @AfterClass
+        fun tearDown() {
+            Mockinizer.shutDown()
+        }
     }
 
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
@@ -6,7 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 
-private const val BASE_URL = "https://my-json-server.typicode.com/typicode/demo/"
+internal const val BASE_URL = "https://my-json-server.typicode.com/typicode/demo/"
 
 object TestApiService {
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockWebServerExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockWebServerExt.kt
@@ -6,10 +6,10 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
 
-internal fun MockWebServer.configure(): MockWebServer {
+internal fun MockWebServer.configure(port: Int = 34567): MockWebServer {
 
     GlobalScope.launch {
-        start(34567)
+        start(port)
     }
 
     val localhostCertificate = HeldCertificate.Builder()

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -10,7 +10,7 @@ import okhttp3.mockwebserver.MockWebServer
 
 class MockinizerInterceptor(
     private val mocks: Map<RequestFilter, MockResponse> = emptyMap(),
-    private val mockServer: MockWebServer = MockWebServer().configure()
+    private val mockServer: MockWebServer
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -69,6 +69,11 @@ object Mockinizer {
     }
 
     @JvmStatic
+    fun start(port: Int = 34567) {
+        mockWebServer?.start(port)
+    }
+
+    @JvmStatic
     fun shutDown() {
         mockWebServer?.shutdown()
     }

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -8,6 +8,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import okio.BufferedSink
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +21,9 @@ internal class MockinizerInterceptorTest {
 
     private val chain: Interceptor.Chain = mock()
 
-    private val systemUnderTest: MockinizerInterceptor = MockinizerInterceptor(mocks)
+    private val mockWebServer : MockWebServer = MockWebServer().configure()
+
+    private val systemUnderTest: MockinizerInterceptor = MockinizerInterceptor(mocks, mockWebServer)
 
     private val realBaseurl = "https://foo.bar"
 


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/20

### Description
- added possibility to modify MockWebserver port and possibilities to customize the MockWebServer that is used with Mockinizer
- MockWebServer can be started / shut down with new static utility methods
- added AndroidTests with demo usage

### Test
- run new androidTests