### PR TITLE
Issue/22 - Set headers default value to null in RequestFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ allprojects {
 Add the below code in the **app module's build.gradle** (Usually you want to implement it only in debug builds and not release builds) At the time of writing the latest mockinizer_version was 1.1.0, you can get **latest release** version here: https://github.com/donfuxx/Mockinizer/releases
 ```gradle
 dependencies {
-    debugImplementation "com.github.donfuxx:Mockinizer:1.2.0"
+    debugImplementation "com.github.donfuxx:Mockinizer:1.3.0"
 }
 ``` 
 You may also need to add a MockWebServer dependency in your app module:

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -103,6 +103,34 @@ internal class MockinizerAndroidTest {
         assertEquals(expectedMethod, actualResponse.raw().request.method)
     }
 
+    @Test
+    fun testShouldCallMockServer_WhenMockHeadersAnyApiCalled() {
+        val actualResponse = TestApiService.testApi.getMockedHeadersAny().execute()
+        val expectedBody = Post(title = "header is ignored")
+        val expectedUrl = "${mockServerUrl}headersAny"
+        val expectedStatusCode = 200
+        val expectedMethod = Method.GET.name
+
+        assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
+        assertEquals(expectedBody, actualResponse.body())
+        assertEquals(expectedStatusCode, actualResponse.code())
+        assertEquals(expectedMethod, actualResponse.raw().request.method)
+    }
+
+    @Test
+    fun testShouldCallMockServer_WhenMockHeadersAnyApi2Called() {
+        val actualResponse = TestApiService.testApi.getMockedHeadersAny2().execute()
+        val expectedBody = Post(title = "header is ignored")
+        val expectedUrl = "${mockServerUrl}headersAny"
+        val expectedStatusCode = 200
+        val expectedMethod = Method.GET.name
+
+        assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
+        assertEquals(expectedBody, actualResponse.body())
+        assertEquals(expectedStatusCode, actualResponse.code())
+        assertEquals(expectedMethod, actualResponse.raw().request.method)
+    }
+
     companion object {
 
         @AfterClass

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
@@ -39,4 +39,17 @@ interface TestApi {
     @GET("headersTooMany")
     fun getMockedHeadersTooMany(): Call<Unit>
 
+    @Headers(
+        "whatever: value"
+    )
+    @GET("headersAny")
+    fun getMockedHeadersAny(): Call<Post>
+
+    @Headers(
+        "any: value",
+        "something: else"
+    )
+    @GET("headersAny")
+    fun getMockedHeadersAny2(): Call<Post>
+
 }

--- a/mockinizer/src/main/java/com/appham/mockinizer/Logger.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/Logger.kt
@@ -1,0 +1,13 @@
+package com.appham.mockinizer
+
+import android.util.Log
+
+object DebugLogger : Logger {
+    override fun d(log: String) {
+        Log.d("Mockinizer", log)
+    }
+}
+
+interface Logger {
+    fun d(log: String)
+}

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -18,7 +18,10 @@ class MockinizerInterceptor(
 
         fun findMockResponse(request: Request): MockResponse? {
             return with(RequestFilter.from(request, log)) {
-                val foundMockResponse = mocks[this] ?: mocks[this.copy(body = null)]
+                val foundMockResponse = mocks[this]
+                    ?: mocks[this.copy(body = null)]
+                    ?: mocks[this.copy(headers = null)]
+                    ?: mocks[this.copy(body = null, headers = null)]
 
                 if (foundMockResponse == null) {
                     log.d("No mocks found for $request")

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -10,14 +10,24 @@ import okhttp3.mockwebserver.MockWebServer
 
 class MockinizerInterceptor(
     private val mocks: Map<RequestFilter, MockResponse> = emptyMap(),
-    private val mockServer: MockWebServer
+    private val mockServer: MockWebServer,
+    private val log: Logger = DebugLogger
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
 
         fun findMockResponse(request: Request): MockResponse? {
-            return with(RequestFilter.from(request)) {
-                mocks[this] ?: mocks[this.copy(body = null)]
+            return with(RequestFilter.from(request, log)) {
+                val foundMockResponse = mocks[this] ?: mocks[this.copy(body = null)]
+
+                if (foundMockResponse == null) {
+                    log.d("No mocks found for $request")
+                } else {
+                    log.d("Found Mock response: $foundMockResponse " +
+                            "for request: $request")
+                }
+
+                foundMockResponse
             }
         }
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -27,12 +27,16 @@ fun OkHttpClient.Builder.mockinize(
     mockWebServer: MockWebServer = MockWebServer().configure(),
     trustManagers: Array<TrustManager> = getAllTrustingManagers(),
     socketFactory: SSLSocketFactory = getSslSocketFactory(trustManagers),
-    hostnameVerifier: HostnameVerifier = HostnameVerifier { _, _ -> true }
+    hostnameVerifier: HostnameVerifier = HostnameVerifier { _, _ -> true },
+    log: Logger = DebugLogger
 ): OkHttpClient.Builder {
     addInterceptor(MockinizerInterceptor(mocks, mockWebServer))
         .sslSocketFactory(socketFactory, trustManagers[0] as X509TrustManager)
         .hostnameVerifier(hostnameVerifier)
     Mockinizer.init(mockWebServer)
+
+    log.d( "Mockinized $this with mocks: $mocks and MockWebServer $mockWebServer")
+
     return this
 }
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -21,13 +21,16 @@ data class RequestFilter(
 
     companion object {
 
-        fun from(request: Request) =
+        fun from(request: Request, log: Logger = DebugLogger) =
             RequestFilter(
                 path = request.url.encodedPath,
                 method = getMethodOrDefault(request.method),
                 body = request.body?.asString(),
                 headers = request.headers
-            )
+            ).also {
+                log.d("Created RequestFilter $it \n" +
+                        " for request: $request")
+            }
 
         private fun getMethodOrDefault(method:String) =
             try {

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -16,7 +16,7 @@ data class RequestFilter(
     val path: String? = null,
     val method: Method = Method.GET,
     val body: String? = null,
-    val headers: Headers = Headers.headersOf()
+    val headers: Headers? = Headers.headersOf()
 ) {
 
     companion object {

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -7,16 +7,17 @@ import okio.Buffer
 
 /**
  * This class is to define the requests that should get filtered and served by the mock server.
+ * Setting a parameter to null means that any values for that parameter should be filtered. 
  * @param path the path part of the request url. The default is null
  * @param method the method of the request. The default is GET
  * @param body the request body. Cannot be used together with GET requests. The default is null
- * @param headers the http headers to filter. The default is empty headers
+ * @param headers the http headers to filter. The default is null headers
  */
 data class RequestFilter(
     val path: String? = null,
     val method: Method = Method.GET,
     val body: String? = null,
-    val headers: Headers? = Headers.headersOf()
+    val headers: Headers? = null
 ) {
 
     companion object {

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/DummyLogger.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/DummyLogger.kt
@@ -1,0 +1,5 @@
+package com.appham.mockinizer
+
+object DummyLogger: Logger {
+    override fun d(log: String) {}
+}

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -54,6 +54,14 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
         headers = Headers.headersOf("name", "value", "foo", "bar")
     ) to MockResponse().apply {
         setResponseCode(200)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/headersAny",
+        headers = null
+    ) to MockResponse().apply {
+        setResponseCode(200)
+        setBody("""{"title":"header is ignored"}""")
     }
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -62,6 +62,14 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
     ) to MockResponse().apply {
         setResponseCode(200)
         setBody("""{"title":"header is ignored"}""")
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/headersNone",
+        headers = Headers.headersOf()
+    ) to MockResponse().apply {
+        setResponseCode(200)
+        setBody("""{"title":"only mocked if no headers at all"}""")
     }
 )
 

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -78,6 +78,10 @@ internal class MockinizerInterceptorTest {
         TestData(RequestFilter(method = PUT, path = "banana", body = """{"type":"apple"}"""), null),
         TestData(RequestFilter(method = POST, path = "banana", body = """{"type":"apple"}"""), null),
         TestData(RequestFilter(method = POST, path = "banana", body = null), null),
+        TestData(RequestFilter(method = GET, path = "/typicode/demo/headersNone", headers = Headers.headersOf("a", "b")),
+            mockResponse = null),
+        TestData(RequestFilter(path = "/typicode/demo/header", headers = Headers.headersOf("a", "b")),
+            mockResponse = null),
 
         // Test requests that actually should get mocked:
         TestData(RequestFilter(method = POST, path = "/typicode/demo/foo", body = """{"type":"apple"}"""),
@@ -104,6 +108,11 @@ internal class MockinizerInterceptorTest {
             mockResponse = MockResponse().apply {
                 setResponseCode(200)
                 setBody("""{"title":"header is ignored"}""")
+            }),
+        TestData(RequestFilter(method = GET, path = "/typicode/demo/headersNone", headers = Headers.headersOf()),
+            mockResponse = MockResponse().apply {
+                setResponseCode(200)
+                setBody("""{"title":"only mocked if no headers at all"}""")
             })
 
         ).apply {

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -23,7 +23,7 @@ internal class MockinizerInterceptorTest {
 
     private val mockWebServer : MockWebServer = MockWebServer().configure()
 
-    private val systemUnderTest: MockinizerInterceptor = MockinizerInterceptor(mocks, mockWebServer)
+    private val systemUnderTest: MockinizerInterceptor = MockinizerInterceptor(mocks, mockWebServer, DummyLogger)
 
     private val realBaseurl = "https://foo.bar"
 

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -2,10 +2,7 @@ package com.appham.mockinizer
 
 import com.appham.mockinizer.Method.*
 import com.nhaarman.mockitokotlin2.*
-import okhttp3.Interceptor
-import okhttp3.MediaType
-import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.*
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -44,7 +41,7 @@ internal class MockinizerInterceptorTest {
                 args.requestFilter.method.name,
                 args.requestFilter.body.orDummyBody(args.requestFilter.method)
             )
-            .headers(args.requestFilter.headers)
+            .headers(args.requestFilter.headers ?: Headers.headersOf())
             .build()
 
         // plugin the request into the MockinizerInterceptor
@@ -102,9 +99,14 @@ internal class MockinizerInterceptorTest {
             mockResponse = MockResponse().apply {
                 setResponseCode(200)
                 setBody("""{"title":"I don't care which body you posted!"}""")
+            }),
+        TestData(RequestFilter(method = GET, path = "/typicode/demo/headersAny", headers = null),
+            mockResponse = MockResponse().apply {
+                setResponseCode(200)
+                setBody("""{"title":"header is ignored"}""")
             })
 
-    ).apply {
+        ).apply {
 
         // All requests from mockinizer mocks map should get mocked:
         addAll(mocks.map { TestData(it.key, it.value) })


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/22

### Description
headers param in RequestFilter can be set to null now to allow filtering of requests with any http headers

### Test
run new androidTests and unit tests