### PR TITLE
Issue/24 - Mockinizer headers are added several times

### DIFF
--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -131,6 +131,17 @@ internal class MockinizerAndroidTest {
         assertEquals(expectedMethod, actualResponse.raw().request.method)
     }
 
+    @Test
+    fun testShouldContainMockinizerHeaders_WhenApiCalled() {
+        val actualResponse = TestApiService.testApi.getMockedHeadersAny2().execute()
+
+        assertEquals("server" to "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin",
+            actualResponse.headers().last())
+        assertEquals("<-- Real request https://my-json-server.typicode.com/typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
+            actualResponse.headers()["Mockinizer"]
+        )
+    }
+
     companion object {
 
         @AfterClass

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -6,9 +6,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 
 internal class MockinizerAndroidTest {
 
-    private val realServerUrl = "https://my-json-server.typicode.com/typicode/demo/"
-    private val mockServerUrl = "https://localhost:34567/typicode/demo/"
-
     @Test
     fun testShouldCallRealServer_WhenPostsApiCalled() {
         val actualResponse = TestApiService.testApi.getPosts().execute()
@@ -132,17 +129,28 @@ internal class MockinizerAndroidTest {
     }
 
     @Test
-    fun testShouldContainMockinizerHeaders_WhenApiCalled() {
+    fun testShouldContainMockinizerHeaders_WhenMockApiCalled() {
         val actualResponse = TestApiService.testApi.getMockedHeadersAny2().execute()
 
-        assertEquals("server" to "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin",
+        assertEquals("server" to mockVersionHeader,
             actualResponse.headers().last())
         assertEquals("<-- Real request https://my-json-server.typicode.com/typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
             actualResponse.headers()["Mockinizer"]
         )
     }
 
+    @Test
+    fun testShouldNotContainMockinizerHeaders_WhenRealApiCalled() {
+        val actualResponse = TestApiService.testApi.getPosts().execute()
+
+        assertEquals(0, actualResponse.headers().values(mockVersionHeader).size)
+    }
+
     companion object {
+
+        private const val realServerUrl = "https://my-json-server.typicode.com/typicode/demo/"
+        private const val mockServerUrl = "https://localhost:34567/typicode/demo/"
+        private const val mockVersionHeader = "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin"
 
         @AfterClass
         fun tearDown() {

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -143,7 +143,19 @@ internal class MockinizerAndroidTest {
     fun testShouldNotContainMockinizerHeaders_WhenRealApiCalled() {
         val actualResponse = TestApiService.testApi.getPosts().execute()
 
-        assertEquals(0, actualResponse.headers().values(mockVersionHeader).size)
+        assertEquals(0, actualResponse.headers().count { (name, value) ->
+            value == mockVersionHeader
+        })
+    }
+
+    @Test
+    fun testShouldNotContainMockinizerHeadersDuplicates_WhenMultipleApiCalls() {
+        TestApiService.testApi.getMockedHeaders().execute()
+        val actualResponse = TestApiService.testApi.getMockedHeaders().execute()
+
+        assertEquals(1, actualResponse.headers().count { (name, value) ->
+            value == mockVersionHeader
+        })
     }
 
     companion object {

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -35,7 +35,7 @@ class MockinizerInterceptor(
         }
 
         fun Interceptor.Chain.findServer(): HttpUrl =
-            when (val mockResponse = findMockResponse(request())) {
+            when (val mockResponse = findMockResponse(request())?.clone()) {
                 is MockResponse -> {
                     mockResponse.addHeader(
                         "Mockinizer",


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/24

### Description
Multiple callings of same mocked endpoint ended up with duplicated headers. Cloned the MockResponse before adding headers to resolve it.

### Test
added unit test to check correct headers are added to mock responses