### PR TITLE
Issue/25 - Simultaneous queries can lead to the wrong responses

### DIFF
--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -141,7 +141,7 @@ internal class MockinizerAndroidTest {
             actualResponse.headers().last()
         )
         assertEquals(
-            "<-- Real request https://my-json-server.typicode.com/typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
+            "<-- Real request /typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
             actualResponse.headers()["Mockinizer"]
         )
     }
@@ -174,9 +174,7 @@ internal class MockinizerAndroidTest {
 
         TestApiService.testApi.getMockedHeadersAny().enqueue(
             object : Callback<Post> {
-                override fun onFailure(call: Call<Post>, t: Throwable) {
-                    TODO("not implemented")
-                }
+                override fun onFailure(call: Call<Post>, t: Throwable) {}
 
                 override fun onResponse(call: Call<Post>, response: Response<Post>) {
                     headersAnyResponseBody = response.body()
@@ -190,9 +188,7 @@ internal class MockinizerAndroidTest {
 
         TestApiService.testApi.getMockedHeadersNone().enqueue(
             object : Callback<Post> {
-                override fun onFailure(call: Call<Post>, t: Throwable) {
-                    TODO("not implemented")
-                }
+                override fun onFailure(call: Call<Post>, t: Throwable) {}
 
                 override fun onResponse(call: Call<Post>, response: Response<Post>) {
                     headersNoneResponseBody = response.body()
@@ -206,9 +202,7 @@ internal class MockinizerAndroidTest {
 
         TestApiService.testApi.getMockedPost(Post(title = "hey ya")).enqueue(
             object : Callback<Post> {
-                override fun onFailure(call: Call<Post>, t: Throwable) {
-                    TODO("not implemented")
-                }
+                override fun onFailure(call: Call<Post>, t: Throwable) {}
 
                 override fun onResponse(call: Call<Post>, response: Response<Post>) {
                     postResponseBody = response.body()

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -3,6 +3,10 @@ package com.appham.mockinizer
 import org.junit.AfterClass
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.util.concurrent.CountDownLatch
 
 internal class MockinizerAndroidTest {
 
@@ -132,9 +136,12 @@ internal class MockinizerAndroidTest {
     fun testShouldContainMockinizerHeaders_WhenMockApiCalled() {
         val actualResponse = TestApiService.testApi.getMockedHeadersAny2().execute()
 
-        assertEquals("server" to mockVersionHeader,
-            actualResponse.headers().last())
-        assertEquals("<-- Real request https://my-json-server.typicode.com/typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
+        assertEquals(
+            "server" to mockVersionHeader,
+            actualResponse.headers().last()
+        )
+        assertEquals(
+            "<-- Real request https://my-json-server.typicode.com/typicode/demo/headersAny is now mocked to HTTP/1.1 200 OK",
             actualResponse.headers()["Mockinizer"]
         )
     }
@@ -158,11 +165,73 @@ internal class MockinizerAndroidTest {
         })
     }
 
+    @Test
+    fun testReturnCorrectResponse_WhenSimultaneousMockApiCalls() {
+
+        val latch = CountDownLatch(3)
+
+        var headersAnyResponseBody: Post? = null
+
+        TestApiService.testApi.getMockedHeadersAny().enqueue(
+            object : Callback<Post> {
+                override fun onFailure(call: Call<Post>, t: Throwable) {
+                    TODO("not implemented")
+                }
+
+                override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                    headersAnyResponseBody = response.body()
+                    latch.countDown()
+                }
+
+            }
+        )
+
+        var headersNoneResponseBody: Post? = null
+
+        TestApiService.testApi.getMockedHeadersNone().enqueue(
+            object : Callback<Post> {
+                override fun onFailure(call: Call<Post>, t: Throwable) {
+                    TODO("not implemented")
+                }
+
+                override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                    headersNoneResponseBody = response.body()
+                    latch.countDown()
+                }
+
+            }
+        )
+
+        var postResponseBody: Post? = null
+
+        TestApiService.testApi.getMockedPost(Post(title = "hey ya")).enqueue(
+            object : Callback<Post> {
+                override fun onFailure(call: Call<Post>, t: Throwable) {
+                    TODO("not implemented")
+                }
+
+                override fun onResponse(call: Call<Post>, response: Response<Post>) {
+                    postResponseBody = response.body()
+                    latch.countDown()
+                }
+
+            }
+        )
+
+        latch.await()
+
+        assertEquals("header is ignored", headersAnyResponseBody?.title)
+        assertEquals("only mocked if no headers at all", headersNoneResponseBody?.title)
+        assertEquals("foobar", postResponseBody?.title)
+
+    }
+
     companion object {
 
         private const val realServerUrl = "https://my-json-server.typicode.com/typicode/demo/"
         private const val mockServerUrl = "https://localhost:34567/typicode/demo/"
-        private const val mockVersionHeader = "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin"
+        private const val mockVersionHeader =
+            "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin"
 
         @AfterClass
         fun tearDown() {

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
@@ -52,4 +52,7 @@ interface TestApi {
     @GET("headersAny")
     fun getMockedHeadersAny2(): Call<Post>
 
+    @GET("headersNone")
+    fun getMockedHeadersNone(): Call<Post>
+
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
@@ -14,34 +14,28 @@ object TestApiService {
     /**
      * Create api interface for posts api
      */
-    val testApi: TestApi by lazy {
+    val testApi: TestApi = {
+
+        val mockWebServer: MockWebServer = MockWebServer().configure()
+
+        val okHttpClient by lazy {
+            val loggingInterceptor = HttpLoggingInterceptor()
+            loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+            OkHttpClient.Builder()
+                .addInterceptor(loggingInterceptor)
+                .mockinize(mocks, mockWebServer)
+                .build()
+        }
+
+        val retrofit by lazy {
+            Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(okHttpClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+        }
+
         retrofit.create(TestApi::class.java)
-    }
-
-    val mockWebServer: MockWebServer = MockWebServer().configure()
-
-    /**
-     * Http client with logging enabled
-     */
-    private val okHttpClient by lazy {
-        val loggingInterceptor = HttpLoggingInterceptor()
-        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
-        OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .mockinize(mocks, mockWebServer)
-            .build()
-    }
-
-    /**
-     * Retrofit instance with Rxjava adapter
-     */
-    private val retrofit by lazy {
-        Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-    }
-
+    }()
 
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
@@ -2,6 +2,7 @@ package com.appham.mockinizer
 
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
 import okhttp3.mockwebserver.MockWebServer
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -16,26 +17,17 @@ object TestApiService {
      */
     val testApi: TestApi = {
 
-        val mockWebServer: MockWebServer = MockWebServer().configure()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
+            .mockinize(mocks, MockWebServer().configure())
+            .build()
 
-        val okHttpClient by lazy {
-            val loggingInterceptor = HttpLoggingInterceptor()
-            loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
-            OkHttpClient.Builder()
-                .addInterceptor(loggingInterceptor)
-                .mockinize(mocks, mockWebServer)
-                .build()
-        }
-
-        val retrofit by lazy {
-            Retrofit.Builder()
-                .baseUrl(BASE_URL)
-                .client(okHttpClient)
-                .addConverterFactory(GsonConverterFactory.create())
-                .build()
-        }
-
-        retrofit.create(TestApi::class.java)
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(TestApi::class.java)
     }()
 
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
@@ -2,6 +2,7 @@ package com.appham.mockinizer
 
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.mockwebserver.MockWebServer
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -17,6 +18,8 @@ object TestApiService {
         retrofit.create(TestApi::class.java)
     }
 
+    val mockWebServer: MockWebServer = MockWebServer().configure()
+
     /**
      * Http client with logging enabled
      */
@@ -25,7 +28,7 @@ object TestApiService {
         loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
         OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
-            .mockinize(mocks)
+            .mockinize(mocks, mockWebServer)
             .build()
     }
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -35,17 +35,8 @@ class MockinizerInterceptor(
         }
 
         fun Interceptor.Chain.findServer(): HttpUrl =
-            when (val mockResponse = findMockResponse(request())?.clone()) {
+            when (findMockResponse(request())) {
                 is MockResponse -> {
-                    mockResponse.addHeader(
-                        "Mockinizer",
-                        " <-- Real request ${request().url} is now mocked to $mockResponse"
-                    )
-                    mockResponse.addHeader(
-                        "server",
-                        "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin"
-                    )
-                    mockServer.enqueue(mockResponse)
                     request().url.newBuilder()
                         .host(mockServer.hostName)
                         .port(mockServer.port)

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -75,14 +75,11 @@ internal class MockDispatcher(private val mocks: Map<RequestFilter, MockResponse
     override fun dispatch(request: RecordedRequest): MockResponse {
         return with(RequestFilter.from(request)) {
             mocks[RequestFilter.from(request)]
-                ?: mocks[this.copy(body = null)]
-                ?: mocks[this.copy(headers = request.headers.withClearedOkhttpHeaders())]
-                ?: mocks[this.copy(headers = null)]
-                ?: mocks[this.copy(
-                    body = null,
-                    headers = request.headers.withClearedOkhttpHeaders()
-                )]
-                ?: mocks[this.copy(body = null, headers = null)]
+                ?: mocks[copy(body = null)]
+                ?: mocks[copy(headers = request.headers.withClearedOkhttpHeaders())]
+                ?: mocks[copy(headers = null)]
+                ?: mocks[copy(body = null, headers = request.headers.withClearedOkhttpHeaders())]
+                ?: mocks[copy(body = null, headers = null)]
                 ?: MockResponse().setResponseCode(404)
         }
     }

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -1,6 +1,5 @@
 package com.appham.mockinizer
 
-import com.appham.mockinizer.Mockinizer.mockWebServer
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
@@ -89,7 +88,7 @@ internal class MockDispatcher(private val mocks: Map<RequestFilter, MockResponse
      */
     private fun Headers.withClearedOkhttpHeaders() =
         if (
-            get(":authority") == "localhost:${mockWebServer?.port}" &&
+            get(":authority")?.startsWith("localhost:") == true &&
             get(":scheme")?.matches("https?".toRegex()) == true &&
             get("accept-encoding") == "gzip" &&
             get("user-agent")?.startsWith("okhttp/") == true
@@ -115,11 +114,11 @@ object Mockinizer {
     ) {
 
         mocks.entries.forEach { (requestFilter, mockResponse) ->
-            mockResponse.addHeader(
+            mockResponse.setHeader(
                 "Mockinizer",
                 " <-- Real request ${requestFilter.path} is now mocked to $mockResponse"
             )
-            mockResponse.addHeader(
+            mockResponse.setHeader(
                 "server",
                 "Mockinizer ${BuildConfig.VERSION_NAME} by Thomas Fuchs-Martin"
             )

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -3,11 +3,12 @@ package com.appham.mockinizer
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.mockwebserver.RecordedRequest
 import okio.Buffer
 
 /**
  * This class is to define the requests that should get filtered and served by the mock server.
- * Setting a parameter to null means that any values for that parameter should be filtered. 
+ * Setting a parameter to null means that any values for that parameter should be filtered.
  * @param path the path part of the request url. The default is null
  * @param method the method of the request. The default is GET
  * @param body the request body. Cannot be used together with GET requests. The default is null
@@ -29,14 +30,29 @@ data class RequestFilter(
                 body = request.body?.asString(),
                 headers = request.headers
             ).also {
-                log.d("Created RequestFilter $it \n" +
-                        " for request: $request")
+                log.d(
+                    "Created RequestFilter $it \n" +
+                            " for request: $request"
+                )
             }
 
-        private fun getMethodOrDefault(method:String) =
+        fun from(request: RecordedRequest, log: Logger = DebugLogger) =
+            RequestFilter(
+                path = request.path,
+                method = getMethodOrDefault(request.method),
+                body = request.body.clone().readUtf8(),
+                headers = request.headers.clearOkhttpHeaders()
+            ).also {
+                log.d(
+                    "Created RequestFilter $it \n" +
+                            " for recorded request: $request"
+                )
+            }
+
+        private fun getMethodOrDefault(method: String?) =
             try {
-                Method.valueOf(method)
-            } catch (e:IllegalArgumentException) {
+                Method.valueOf(method.orEmpty())
+            } catch (e: IllegalArgumentException) {
                 Method.GET
             }
     }
@@ -51,3 +67,15 @@ fun RequestBody.asString(): String {
     writeTo(buffer)
     return buffer.readUtf8()
 }
+
+fun RecordedRequest.asString(): String {
+    return "$path  - $method - ${body.clone().readUtf8()} - $headers"
+}
+
+fun Headers.clearOkhttpHeaders() =
+    newBuilder()
+        .removeAll(":authority")
+        .removeAll(":scheme")
+        .removeAll("accept-encoding")
+        .removeAll("user-agent")
+        .build()

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -41,7 +41,7 @@ data class RequestFilter(
                 path = request.path,
                 method = getMethodOrDefault(request.method),
                 body = request.body.clone().readUtf8(),
-                headers = request.headers.clearOkhttpHeaders()
+                headers = request.headers
             ).also {
                 log.d(
                     "Created RequestFilter $it \n" +
@@ -71,11 +71,3 @@ fun RequestBody.asString(): String {
 fun RecordedRequest.asString(): String {
     return "$path  - $method - ${body.clone().readUtf8()} - $headers"
 }
-
-fun Headers.clearOkhttpHeaders() =
-    newBuilder()
-        .removeAll(":authority")
-        .removeAll(":scheme")
-        .removeAll("accept-encoding")
-        .removeAll("user-agent")
-        .build()


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/25

### Description
- MockWebServer uses now Dispatcher to allow ensure simultaneous requests get the correct response
- a bit of refactoring included: The mockinizer http headers get now added once in Mockinizer.init already

### Test
- androidTest added that would simulate multiple simultaneous requests and verifies the correct responses
