### PR TITLE
Issue/28 - Regression from 1.4.0: Requests with query parameters don't succeed anymore

### DIFF
--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -223,7 +223,7 @@ internal class MockinizerAndroidTest {
     @Test
     fun testShouldCallMockServer_WhenMockQueryParamApiCalled() {
         val actualResponse = TestApiService.testApi.getMockedQueryParam().execute()
-        val expectedBody = null
+        val expectedBody = Unit
         val expectedUrl = "${mockServerUrl}query?param=foo"
         val expectedStatusCode = 200
 

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -233,11 +233,23 @@ internal class MockinizerAndroidTest {
     }
 
     @Test
-    fun testShouldCallRealServer_WhenMockQueryParamApiCalledWithUnknownParams() {
-        val actualResponse = TestApiService.testApi.getMockedQueryParam("unknown").execute()
+    fun testShouldCallRealServer_WhenMockQueryOnlyApiCalledWithUnknownParams() {
+        val actualResponse = TestApiService.testApi.getMockedQueryOnly("unknown").execute()
         val expectedBody = null
-        val expectedUrl = "${realServerUrl}query?param=unknown"
+        val expectedUrl = "${realServerUrl}queryOnly?param=unknown"
         val expectedStatusCode = 404
+
+        assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
+        assertEquals(expectedBody, actualResponse.body())
+        assertEquals(expectedStatusCode, actualResponse.code())
+    }
+
+    @Test
+    fun testShouldCallMockServer_WhenMockQueryAnyApiCalledWithParams() {
+        val actualResponse = TestApiService.testApi.getMockedQueryAny("unknown").execute()
+        val expectedBody = null
+        val expectedUrl = "${mockServerUrl}queryAny?param=unknown"
+        val expectedStatusCode = 401
 
         assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
         assertEquals(expectedBody, actualResponse.body())

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -220,6 +220,18 @@ internal class MockinizerAndroidTest {
 
     }
 
+    @Test
+    fun testShouldCallMockServer_WhenMockQueryParamApiCalled() {
+        val actualResponse = TestApiService.testApi.getMockedQueryParam().execute()
+        val expectedBody = null
+        val expectedUrl = "${mockServerUrl}query?param=foo"
+        val expectedStatusCode = 200
+
+        assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
+        assertEquals(expectedBody, actualResponse.body())
+        assertEquals(expectedStatusCode, actualResponse.code())
+    }
+
     companion object {
 
         private const val realServerUrl = "https://my-json-server.typicode.com/typicode/demo/"

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/MockinizerAndroidTest.kt
@@ -222,10 +222,22 @@ internal class MockinizerAndroidTest {
 
     @Test
     fun testShouldCallMockServer_WhenMockQueryParamApiCalled() {
-        val actualResponse = TestApiService.testApi.getMockedQueryParam().execute()
+        val actualResponse = TestApiService.testApi.getMockedQueryParam("foo").execute()
         val expectedBody = Unit
         val expectedUrl = "${mockServerUrl}query?param=foo"
         val expectedStatusCode = 200
+
+        assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
+        assertEquals(expectedBody, actualResponse.body())
+        assertEquals(expectedStatusCode, actualResponse.code())
+    }
+
+    @Test
+    fun testShouldCallRealServer_WhenMockQueryParamApiCalledWithUnknownParams() {
+        val actualResponse = TestApiService.testApi.getMockedQueryParam("unknown").execute()
+        val expectedBody = null
+        val expectedUrl = "${realServerUrl}query?param=unknown"
+        val expectedStatusCode = 404
 
         assertEquals(expectedUrl, actualResponse.raw().request.url.toString())
         assertEquals(expectedBody, actualResponse.body())

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
@@ -55,4 +55,7 @@ interface TestApi {
     @GET("headersNone")
     fun getMockedHeadersNone(): Call<Post>
 
+    @GET("query?param=foo")
+    fun getMockedQueryParam(): Call<Unit>
+
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
@@ -58,4 +58,10 @@ interface TestApi {
     @GET("query")
     fun getMockedQueryParam(@Query("param") param: String? = null): Call<Unit>
 
+    @GET("queryAny")
+    fun getMockedQueryAny(@Query("param") param: String? = null): Call<Unit>
+
+    @GET("queryOnly")
+    fun getMockedQueryOnly(@Query("param") param: String? = null): Call<Unit>
+
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApi.kt
@@ -55,7 +55,7 @@ interface TestApi {
     @GET("headersNone")
     fun getMockedHeadersNone(): Call<Post>
 
-    @GET("query?param=foo")
-    fun getMockedQueryParam(): Call<Unit>
+    @GET("query")
+    fun getMockedQueryParam(@Query("param") param: String? = null): Call<Unit>
 
 }

--- a/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
+++ b/mockinizer/src/androidTest/java/com/appham/mockinizer/TestApiService.kt
@@ -6,6 +6,7 @@ import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
 import okhttp3.mockwebserver.MockWebServer
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 
 
 internal const val BASE_URL = "https://my-json-server.typicode.com/typicode/demo/"
@@ -19,6 +20,10 @@ object TestApiService {
 
         val okHttpClient = OkHttpClient.Builder()
             .addInterceptor(HttpLoggingInterceptor().apply { level = BODY })
+            .callTimeout(5, TimeUnit.MINUTES)
+            .connectTimeout(5, TimeUnit.MINUTES)
+            .readTimeout(5, TimeUnit.MINUTES)
+            .writeTimeout(5, TimeUnit.MINUTES)
             .mockinize(mocks, MockWebServer().configure())
             .build()
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/MockinizerInterceptor.kt
@@ -19,9 +19,13 @@ class MockinizerInterceptor(
         fun findMockResponse(request: Request): MockResponse? {
             return with(RequestFilter.from(request, log)) {
                 val foundMockResponse = mocks[this]
-                    ?: mocks[this.copy(body = null)]
-                    ?: mocks[this.copy(headers = null)]
-                    ?: mocks[this.copy(body = null, headers = null)]
+                    ?: mocks[copy(body = null)]
+                    ?: mocks[copy(headers = null)]
+                    ?: mocks[copy(query = null)]
+                    ?: mocks[copy(body = null, headers = null)]
+                    ?: mocks[copy(body = null, query = null)]
+                    ?: mocks[copy(headers = null, query = null)]
+                    ?: mocks[copy(body = null, headers = null, query = null)]
 
                 if (foundMockResponse == null) {
                     log.d("No mocks found for $request")

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -77,9 +77,20 @@ internal class MockDispatcher(private val mocks: Map<RequestFilter, MockResponse
                 ?: mocks[copy(body = null)]
                 ?: mocks[copy(headers = request.headers.withClearedOkhttpHeaders())]
                 ?: mocks[copy(headers = null)]
+                ?: mocks[copy(query = null)]
                 ?: mocks[copy(body = null, headers = request.headers.withClearedOkhttpHeaders())]
                 ?: mocks[copy(body = null, headers = null)]
-                ?: MockResponse().setResponseCode(404)
+                ?: mocks[copy(body = null, query = null)]
+                ?: mocks[copy(headers = null, query = null)]
+                ?: mocks[copy(headers = request.headers.withClearedOkhttpHeaders(), query = null)]
+                ?: mocks[copy(body = null, headers = null, query = null)]
+                ?: mocks[copy(body = null, headers = request.headers.withClearedOkhttpHeaders(), query = null)]
+                ?: MockResponse()
+                    .setResponseCode(404)
+                    .setBody("""{
+                        |"error":"Mockinizer ${BuildConfig.VERSION_NAME} could not dispatch response for $request", 
+                        |"requestFilter":"$this""
+                        |}""".trimMargin())
         }
     }
 

--- a/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/OkHttpClientExt.kt
@@ -73,7 +73,7 @@ internal class MockDispatcher(private val mocks: Map<RequestFilter, MockResponse
     @Throws(InterruptedException::class)
     override fun dispatch(request: RecordedRequest): MockResponse {
         return with(RequestFilter.from(request)) {
-            mocks[RequestFilter.from(request)]
+            mocks[this]
                 ?: mocks[copy(body = null)]
                 ?: mocks[copy(headers = request.headers.withClearedOkhttpHeaders())]
                 ?: mocks[copy(headers = null)]

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -10,12 +10,14 @@ import okio.Buffer
  * This class is to define the requests that should get filtered and served by the mock server.
  * Setting a parameter to null means that any values for that parameter should be filtered.
  * @param path the path part of the request url. The default is null
+ * @param query the query part of the request url. The default is null
  * @param method the method of the request. The default is GET
  * @param body the request body. Cannot be used together with GET requests. The default is null
  * @param headers the http headers to filter. The default is null headers
  */
 data class RequestFilter(
     val path: String? = null,
+    val query: String? = null,
     val method: Method = Method.GET,
     val body: String? = null,
     val headers: Headers? = null
@@ -25,7 +27,8 @@ data class RequestFilter(
 
         fun from(request: Request, log: Logger = DebugLogger) =
             RequestFilter(
-                path = request.urlWithQueryParams(),
+                path = request.url.encodedPath,
+                query = request.url.encodedQuery,
                 method = getMethodOrDefault(request.method),
                 body = request.body?.asString(),
                 headers = request.headers
@@ -38,7 +41,8 @@ data class RequestFilter(
 
         fun from(request: RecordedRequest, log: Logger = DebugLogger) =
             RequestFilter(
-                path = request.path,
+                path = request.requestUrl?.encodedPath,
+                query = request.requestUrl?.encodedQuery,
                 method = getMethodOrDefault(request.method),
                 body = request.body.clone().readUtf8(),
                 headers = request.headers
@@ -57,12 +61,6 @@ data class RequestFilter(
             }
     }
 }
-
-private fun Request.urlWithQueryParams(): String =
-    when (val query = url.encodedQuery) {
-        null -> url.encodedPath
-        else -> url.encodedPath.plus("?").plus(query)
-    }
 
 enum class Method {
     GET, POST, PUT, PATCH, DELETE;

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -66,6 +66,11 @@ enum class Method {
     GET, POST, PUT, PATCH, DELETE;
 }
 
+fun RequestFilter.url(): String = when (query.isNullOrBlank()) {
+    true -> path.orEmpty()
+    false -> path.orEmpty().plus("?").plus(query)
+}
+
 fun RequestBody.asString(): String {
     val buffer = Buffer()
     writeTo(buffer)

--- a/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
+++ b/mockinizer/src/main/java/com/appham/mockinizer/RequestFilter.kt
@@ -25,7 +25,7 @@ data class RequestFilter(
 
         fun from(request: Request, log: Logger = DebugLogger) =
             RequestFilter(
-                path = request.url.encodedPath,
+                path = request.urlWithQueryParams(),
                 method = getMethodOrDefault(request.method),
                 body = request.body?.asString(),
                 headers = request.headers
@@ -57,6 +57,12 @@ data class RequestFilter(
             }
     }
 }
+
+private fun Request.urlWithQueryParams(): String =
+    when (val query = url.encodedQuery) {
+        null -> url.encodedPath
+        else -> url.encodedPath.plus("?").plus(query)
+    }
 
 enum class Method {
     GET, POST, PUT, PATCH, DELETE;

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -88,6 +88,12 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
         path = "/typicode/demo/query?hey=ho"
     ) to MockResponse().apply {
         setResponseCode(400)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/query?hey=ho&bla=la"
+    ) to MockResponse().apply {
+        setResponseCode(404)
     }
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -105,6 +105,27 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
         query = null
     ) to MockResponse().apply {
         setResponseCode(410)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/queryAny",
+        query = null
+    ) to MockResponse().apply {
+        setResponseCode(401)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/queryOnly",
+        query = "b=c"
+    ) to MockResponse().apply {
+        setResponseCode(403)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/queryOnly",
+        query = null
+    ) to MockResponse().apply {
+        setResponseCode(503)
     }
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -70,6 +70,12 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
     ) to MockResponse().apply {
         setResponseCode(200)
         setBody("""{"title":"only mocked if no headers at all"}""")
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/query?param=foo"
+    ) to MockResponse().apply {
+        setResponseCode(200)
     }
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -119,13 +119,7 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
         query = "b=c"
     ) to MockResponse().apply {
         setResponseCode(403)
-    },
-
-    RequestFilter(
-        path = "/typicode/demo/queryOnly",
-        query = null
-    ) to MockResponse().apply {
-        setResponseCode(503)
     }
+
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -73,27 +73,38 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
     },
 
     RequestFilter(
-        path = "/typicode/demo/query?param=foo"
+        path = "/typicode/demo/query",
+        query = "param=foo"
     ) to MockResponse().apply {
         setResponseCode(200)
     },
 
     RequestFilter(
-        path = "/typicode/demo/query?param=boom"
+        path = "/typicode/demo/query",
+        query = "param=boom"
     ) to MockResponse().apply {
         setResponseCode(500)
     },
 
     RequestFilter(
-        path = "/typicode/demo/query?hey=ho"
+        path = "/typicode/demo/query",
+        query = "hey=ho"
     ) to MockResponse().apply {
         setResponseCode(400)
     },
 
     RequestFilter(
-        path = "/typicode/demo/query?hey=ho&bla=la"
+        path = "/typicode/demo/query",
+        query = "hey=ho&bla=la"
     ) to MockResponse().apply {
-        setResponseCode(404)
+        setResponseCode(503)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/query",
+        query = null
+    ) to MockResponse().apply {
+        setResponseCode(410)
     }
 )
 

--- a/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
+++ b/mockinizer/src/sharedTest/java/com/appham/mockinizer/Mocks.kt
@@ -76,6 +76,18 @@ val mocks: Map<RequestFilter, MockResponse> = mapOf(
         path = "/typicode/demo/query?param=foo"
     ) to MockResponse().apply {
         setResponseCode(200)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/query?param=boom"
+    ) to MockResponse().apply {
+        setResponseCode(500)
+    },
+
+    RequestFilter(
+        path = "/typicode/demo/query?hey=ho"
+    ) to MockResponse().apply {
+        setResponseCode(400)
     }
 )
 

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -34,7 +34,7 @@ internal class MockinizerInterceptorTest {
     fun `Should mock response When RequestFilter contains request On intercept`(args: TestData) {
 
         // build a request for the chain to be intercepted by MockinizerInterceptor
-        val requestUrl = "$realBaseurl${args.requestFilter.path.orEmpty()}"
+        val requestUrl = "$realBaseurl${args.requestFilter.url()}"
         val request = Request.Builder()
             .url(requestUrl)
             .method(
@@ -82,6 +82,7 @@ internal class MockinizerInterceptorTest {
             mockResponse = null),
         TestData(RequestFilter(path = "/typicode/demo/header", headers = Headers.headersOf("a", "b")),
             mockResponse = null),
+        TestData(RequestFilter(path = "/typicode/demo/querynomock", query = "param=foo"), null),
 
         // Test requests that actually should get mocked:
         TestData(RequestFilter(method = POST, path = "/typicode/demo/foo", body = """{"type":"apple"}"""),

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -114,6 +114,10 @@ internal class MockinizerInterceptorTest {
             mockResponse = MockResponse().apply {
                 setResponseCode(200)
                 setBody("""{"title":"only mocked if no headers at all"}""")
+            }),
+        TestData(RequestFilter(path = "/typicode/demo/query", query = "a=b"),
+            mockResponse = MockResponse().apply {
+                setResponseCode(503)
             })
 
         ).apply {

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -22,7 +22,7 @@ internal class MockinizerInterceptorTest {
 
     private val systemUnderTest: MockinizerInterceptor = MockinizerInterceptor(mocks, mockWebServer, DummyLogger)
 
-    private val realBaseurl = "https://foo.bar"
+    private val realBaseurl = "https://real.api"
 
     @BeforeEach
     fun setup() {

--- a/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
+++ b/mockinizer/src/test/java/com/appham/mockinizer/MockinizerInterceptorTest.kt
@@ -83,6 +83,7 @@ internal class MockinizerInterceptorTest {
         TestData(RequestFilter(path = "/typicode/demo/header", headers = Headers.headersOf("a", "b")),
             mockResponse = null),
         TestData(RequestFilter(path = "/typicode/demo/querynomock", query = "param=foo"), null),
+        TestData(RequestFilter(path = "/typicode/demo/queryOnly", query = "param=foo"), null),
 
         // Test requests that actually should get mocked:
         TestData(RequestFilter(method = POST, path = "/typicode/demo/foo", body = """{"type":"apple"}"""),
@@ -118,6 +119,10 @@ internal class MockinizerInterceptorTest {
         TestData(RequestFilter(path = "/typicode/demo/query", query = "a=b"),
             mockResponse = MockResponse().apply {
                 setResponseCode(503)
+            }),
+        TestData(RequestFilter(path = "/typicode/demo/queryAny", query = "what=ever"),
+            mockResponse = MockResponse().apply {
+                setResponseCode(502)
             })
 
         ).apply {


### PR DESCRIPTION
Issue link: https://github.com/donfuxx/Mockinizer/issues/28

### Description
- added tests for mocking urls with query params
- ~~query params can get added to RequestFilter's path now~~ <-- Changed my mind on this and added a separate `query` field to `RequestFilter`. query == null means any query will get mocked.

### Test
run new unit tests